### PR TITLE
update snippet to reduce line length

### DIFF
--- a/lib/snippet.handlebars
+++ b/lib/snippet.handlebars
@@ -1,17 +1,17 @@
 // Create a queue, but don't obliterate an existing one!
-window.analytics || (window.analytics = []);
+window.analytics = window.analytics || [];
 
-// A list of all the methods in analytics.js that we want to stub.
-window.analytics.methods = ['identify', 'track', 'trackLink', 'trackForm',
-'trackClick', 'trackSubmit', 'page', 'pageview', 'ab', 'alias', 'ready',
-'group', 'on', 'once', 'off'];
+// A list of the methods in Analytics.js to stub.
+window.analytics.methods = ['identify', 'group', 'track',
+  'page', 'pageview', 'alias', 'ready', 'on', 'once', 'off',
+  'trackLink', 'trackForm', 'trackClick', 'trackSubmit'];
 
-// Define a factory to create queue stubs. These are placeholders for the
-// "real" methods in analytics.js so that you never have to wait for the library
-// to load asynchronously to actually track things. The `method` is always the
-// first argument, so we know which method to replay the call into.
-window.analytics.factory = function (method) {
-  return function () {
+// Define a factory to create stubs. These are placeholders
+// for methods in Analytics.js so that you never have to wait
+// for it to load to actually record data. The `method` is
+// stored as the first argument, so we can replay the data.
+window.analytics.factory = function(method){
+  return function(){
     var args = Array.prototype.slice.call(arguments);
     args.unshift(method);
     window.analytics.push(args);
@@ -19,35 +19,40 @@ window.analytics.factory = function (method) {
   };
 };
 
-// For each of our methods, generate a queueing method.
+// For each of our methods, generate a queueing stub.
 for (var i = 0; i < window.analytics.methods.length; i++) {
-  var method = window.analytics.methods[i];
-  window.analytics[method] = window.analytics.factory(method);
+  var key = window.analytics.methods[i];
+  window.analytics[key] = window.analytics.factory(key);
 }
 
-// Define a method that will asynchronously load analytics.js from our CDN.
-window.analytics.load = function (apiKey) {
-  if (document.getElementById('analyticsjs')) return;
-  // Create an async script element for analytics.js based on your API key.
+// Define a method to load Analytics.js from our CDN,
+// and that will be sure to only ever load it once.
+window.analytics.load = function(key){
+  if (document.getElementById('analytics-js')) return;
+
+  // Create an async script element based on your key.
   var script = document.createElement('script');
   script.type = 'text/javascript';
-  script.id = 'analyticsjs';
+  script.id = 'analytics-js';
   script.async = true;
-  script.src = ('https:' === document.location.protocol ? 'https://' : 'http://') +
-                '{{{ host }}}/analytics.js/v1/' + apiKey + '/analytics.min.js';
+  script.src = ('https:' === document.location.protocol
+    ? 'https://' : 'http://')
+    + '{{{ host }}}/analytics.js/v1/'
+    + key + '/analytics.min.js';
 
-  // Find the first script element on the page and insert our script next to it.
-  var firstScript = document.getElementsByTagName('script')[0];
-  firstScript.parentNode.insertBefore(script, firstScript);
+  // Insert our script next to the first script element.
+  var first = document.getElementsByTagName('script')[0];
+  first.parentNode.insertBefore(script, first);
 };
 
-// Add a version so we can keep track of what's out there in the wild.
+// Add a version to keep track of what's in the wild.
 window.analytics.SNIPPET_VERSION = '2.0.8';
 
-// Load analytics.js with your API key, which will automatically load all of the
-// analytics integrations you've turned on for your account. Boosh!
+// Load Analytics.js with your key, which will automatically
+// load the tools you've enabled for your account. Boosh!
 window.analytics.load('{{{ apiKey }}}');
 
-// Make our first page call to load the integrations. If you'd like to manually
-// name or tag the page, edit or move this call to use your own tags.
+// Make the first page call to load the integrations. If
+// you'd like to manually name or tag the page, edit or
+// move this call however you'd like.
 /* {{! window.analytics.page call gets appended here }} */

--- a/test/browser.js
+++ b/test/browser.js
@@ -60,10 +60,6 @@ describe('snippet', function () {
       assert(contains(window.analytics.methods, 'pageview'));
     });
 
-    it('.ab', function () {
-      assert(contains(window.analytics.methods, 'ab'));
-    });
-
     it('.alias', function () {
       assert(contains(window.analytics.methods, 'alias'));
     });


### PR DESCRIPTION
@yields 

removed `ab` since with the new semantic event names system looks like we wont need it in the future anyways. i think everything else should be good though, but might have missed something important
