### PR TITLE
fix: make sure the snippet is included once

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,15 @@ PHANTOM = node_modules/.bin/mocha-phantomjs --setting web-security=false --setti
 MOCHA = node_modules/.bin/mocha
 COMPONENT = node_modules/component/bin/component
 
-build: install
+build: node_modules components
 	@$(COMPONENT) build --dev
 
-install: package.json component.json
+components: component.json
 	@$(COMPONENT) install --dev
-	@npm install .
+
+node_modules: package.json
+	@npm install
+	@touch $@
 
 clean:
 	@rm -rf build components

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,7 +23,6 @@ var templateFile = path.resolve(__dirname, './snippet.handlebars');
 
 var template = fs.readFileSync(templateFile, 'utf8');
 
-
 /**
  * The compiled versions of the template
  */

--- a/lib/snippet.handlebars
+++ b/lib/snippet.handlebars
@@ -1,58 +1,67 @@
 // Create a queue, but don't obliterate an existing one!
 window.analytics = window.analytics || [];
 
-// A list of the methods in Analytics.js to stub.
-window.analytics.methods = ['identify', 'group', 'track',
-  'page', 'pageview', 'alias', 'ready', 'on', 'once', 'off',
-  'trackLink', 'trackForm', 'trackClick', 'trackSubmit'];
+// If analytics was included show an error.
+if (window.analytics.included) {
+  if (window.console && console.error) {
+    console.error('analytics.js included twice');
+  }
+} else {
 
-// Define a factory to create stubs. These are placeholders
-// for methods in Analytics.js so that you never have to wait
-// for it to load to actually record data. The `method` is
-// stored as the first argument, so we can replay the data.
-window.analytics.factory = function(method){
-  return function(){
-    var args = Array.prototype.slice.call(arguments);
-    args.unshift(method);
-    window.analytics.push(args);
-    return window.analytics;
+  // included.
+  window.analytics.included = true;
+
+  // A list of the methods in Analytics.js to stub.
+  window.analytics.methods = ['identify', 'group', 'track',
+    'page', 'pageview', 'alias', 'ready', 'on', 'once', 'off',
+    'trackLink', 'trackForm', 'trackClick', 'trackSubmit'];
+
+  // Define a factory to create stubs. These are placeholders
+  // for methods in Analytics.js so that you never have to wait
+  // for it to load to actually record data. The `method` is
+  // stored as the first argument, so we can replay the data.
+  window.analytics.factory = function(method){
+    return function(){
+      var args = Array.prototype.slice.call(arguments);
+      args.unshift(method);
+      window.analytics.push(args);
+      return window.analytics;
+    };
   };
-};
 
-// For each of our methods, generate a queueing stub.
-for (var i = 0; i < window.analytics.methods.length; i++) {
-  var key = window.analytics.methods[i];
-  window.analytics[key] = window.analytics.factory(key);
+  // For each of our methods, generate a queueing stub.
+  for (var i = 0; i < window.analytics.methods.length; i++) {
+    var key = window.analytics.methods[i];
+    window.analytics[key] = window.analytics.factory(key);
+  }
+
+  // Define a method to load Analytics.js from our CDN,
+  // and that will be sure to only ever load it once.
+  window.analytics.load = function(key){
+    // Create an async script element based on your key.
+    var script = document.createElement('script');
+    script.type = 'text/javascript';
+    script.async = true;
+    script.src = ('https:' === document.location.protocol
+      ? 'https://' : 'http://')
+      + '{{{ host }}}/analytics.js/v1/'
+      + key + '/analytics.min.js';
+
+    // Insert our script next to the first script element.
+    var first = document.getElementsByTagName('script')[0];
+    first.parentNode.insertBefore(script, first);
+  };
+
+  // Add a version to keep track of what's in the wild.
+  window.analytics.SNIPPET_VERSION = '2.0.9';
+
+  // Load Analytics.js with your key, which will automatically
+  // load the tools you've enabled for your account. Boosh!
+  window.analytics.load('{{{ apiKey }}}');
+
+  // Make the first page call to load the integrations. If
+  // you'd like to manually name or tag the page, edit or
+  // move this call however you'd like.
+  /* {{! window.analytics.page call gets appended here }} */
+ 
 }
-
-// Define a method to load Analytics.js from our CDN,
-// and that will be sure to only ever load it once.
-window.analytics.load = function(key){
-  if (document.getElementById('analytics-js')) return;
-
-  // Create an async script element based on your key.
-  var script = document.createElement('script');
-  script.type = 'text/javascript';
-  script.id = 'analytics-js';
-  script.async = true;
-  script.src = ('https:' === document.location.protocol
-    ? 'https://' : 'http://')
-    + '{{{ host }}}/analytics.js/v1/'
-    + key + '/analytics.min.js';
-
-  // Insert our script next to the first script element.
-  var first = document.getElementsByTagName('script')[0];
-  first.parentNode.insertBefore(script, first);
-};
-
-// Add a version to keep track of what's in the wild.
-window.analytics.SNIPPET_VERSION = '2.0.9';
-
-// Load Analytics.js with your key, which will automatically
-// load the tools you've enabled for your account. Boosh!
-window.analytics.load('{{{ apiKey }}}');
-
-// Make the first page call to load the integrations. If
-// you'd like to manually name or tag the page, edit or
-// move this call however you'd like.
-/* {{! window.analytics.page call gets appended here }} */

--- a/test/browser.js
+++ b/test/browser.js
@@ -15,7 +15,16 @@ describe('snippet', function () {
     var length = scripts.length;
     Function(snippet.textContent)();
     assert(length == scripts.length);
-  })
+  });
+
+  it('should not error when window.console is unavailable', function(){
+    window.analytics.included = true;
+    var scripts = document.getElementsByTagName('script');
+    var c = console;
+    window.console = null;
+    Function(snippet.textContent)();
+    window.console = c;
+  });
 
   describe('.page', function () {
     it('should call .page by default', function () {


### PR DESCRIPTION
closes #15 
- checks for `analytics.included`
- if it's `true`, checks for `console.error` and logs an error
- if it's not `included` it will invoke the snippet

this solves the stack call exceeded errors, when users inadvertently include the snippet twice :/

cc @calvinfo 
