### PR TITLE
snippet: fix ajax loading stack overflow case

### DIFF
--- a/lib/snippet.js
+++ b/lib/snippet.js
@@ -3,6 +3,9 @@
   // Create a queue, but don't obliterate an existing one!
   var analytics = window.analytics = window.analytics || [];
 
+  // If the real analytics.js is already on the page return.
+  if (analytics.initialize) return;
+
   // If the snippet was invoked already show an error.
   if (analytics.invoked) {
     if (window.console && console.error) {

--- a/test/browser.js
+++ b/test/browser.js
@@ -35,6 +35,18 @@ describe('snippet', function () {
     assert.equal('Segment snippet included twice.', args[0][0]);
   });
 
+  it('should ignore the snippet when the real analytics is already included', function(){
+    var global = {};
+    var ajs = { initialize: function(){} };
+    global.window = global;
+    global.analytics = ajs;
+    global.console = { error: spy() };
+    with (global) eval(snippet);
+    var args = global.console.error.args;
+    assert.equal(ajs, global.analytics);
+    assert.equal(0, args.length);
+  });
+
   it('should not call .page() again when included > 1', function(){
     var global = {};
     global.window = global;


### PR DESCRIPTION
https://github.com/segmentio/analytics.js/issues/422

When a developer reloads the whole page using ajax
the snippet re-defines the real loaded analytics
then each method call will in return call .push() recursively

cc @calvinfo 