### PR TITLE
last version of minify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 node_modules
 components
 test/build.js
+npm-debug.log
+
+test.js

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "handlebars": "~1.1.2",
-    "minify": "git://github.com/segmentio/minify",
-    "hbs": "~2.4.0"
+    "hbs": "~2.4.0",
+    "minify": "^2.0.3"
   }
 }


### PR DESCRIPTION
Prevent from error
Error: Cannot find module './htmlparser' from
'/node_modules/segmentio-snippet/node_modules/html-minifier/dist'
when you try to browserify
