### PR TITLE
added integration options to load

### DIFF
--- a/karma.conf.ci.js
+++ b/karma.conf.ci.js
@@ -33,11 +33,6 @@ var customLaunchers = {
     browserName: 'safari',
     version: '9.0'
   },
-  sl_ie_8: {
-    base: 'SauceLabs',
-    browserName: 'internet explorer',
-    version: '8'
-  },
   sl_ie_9: {
     base: 'SauceLabs',
     browserName: 'internet explorer',

--- a/template/snippet.js
+++ b/template/snippet.js
@@ -59,7 +59,7 @@
 
   // Define a method to load Analytics.js from our CDN,
   // and that will be sure to only ever load it once.
-  analytics.load = function(key, integrationOptions){
+  analytics.load = function(key, options){
     // Create an async script element based on your key.
     var script = document.createElement('script');
     script.type = 'text/javascript';
@@ -72,11 +72,11 @@
     // Insert our script next to the first script element.
     var first = document.getElementsByTagName('script')[0];
     first.parentNode.insertBefore(script, first);
-    analytics._integrationOptions = integrationOptions;
+    analytics._loadOptions = options;
   };
 
   // Add a version to keep track of what's in the wild.
-  analytics.SNIPPET_VERSION = '4.0.1';
+  analytics.SNIPPET_VERSION = '4.1.0';
 
   // Load Analytics.js with your key, which will automatically
   // load the tools you've enabled for your account. Boosh!

--- a/template/snippet.js
+++ b/template/snippet.js
@@ -72,7 +72,7 @@
     // Insert our script next to the first script element.
     var first = document.getElementsByTagName('script')[0];
     first.parentNode.insertBefore(script, first);
-    analytics.integrationOptions = integrationOptions;
+    analytics._integrationOptions = integrationOptions;
   };
 
   // Add a version to keep track of what's in the wild.

--- a/template/snippet.js
+++ b/template/snippet.js
@@ -59,7 +59,7 @@
 
   // Define a method to load Analytics.js from our CDN,
   // and that will be sure to only ever load it once.
-  analytics.load = function(key){
+  analytics.load = function(key, integrationOptions){
     // Create an async script element based on your key.
     var script = document.createElement('script');
     script.type = 'text/javascript';
@@ -72,10 +72,11 @@
     // Insert our script next to the first script element.
     var first = document.getElementsByTagName('script')[0];
     first.parentNode.insertBefore(script, first);
+    analytics.integrationOptions = integrationOptions;
   };
 
   // Add a version to keep track of what's in the wild.
-  analytics.SNIPPET_VERSION = '4.0.0';
+  analytics.SNIPPET_VERSION = '4.0.1';
 
   // Load Analytics.js with your key, which will automatically
   // load the tools you've enabled for your account. Boosh!


### PR DESCRIPTION
Adds an option for customer to pass integration-specific options to `load` like so:

```
player = new Player()
analytics.load("K3wz25G4iMGTJcuHFOWeuAWk6BBfwF3e", {
  integrations: {
    Youbora: {
      videoplayer: player
    }
  }
});
```

More context here: https://paper.dropbox.com/doc/Spec-Extending-A.js-load-Functionality-7YGS8OiipIFqaKwxLMQCt

Linked to https://github.com/segmentio/analytics.js-private/pull/210