### PR TITLE
rename addDestinationMiddleware to addIntegrationMiddleware

### DIFF
--- a/template/snippet.js
+++ b/template/snippet.js
@@ -37,7 +37,7 @@
     'off',
     'on',
     'addSourceMiddleware',
-    'addDestinationMiddleware'
+    'addIntegrationMiddleware'
   ];
 
   // Define a factory to create stubs. These are placeholders

--- a/test/snippet.test.js
+++ b/test/snippet.test.js
@@ -150,8 +150,8 @@ describe('snippet', function() {
       assert(arrayContains(window.analytics.methods, 'addSourceMiddleware'));
     });
 
-    it('.addDestinationMiddleware', function() {
-      assert(arrayContains(window.analytics.methods, 'addDestinationMiddleware'));
+    it('.addIntegrationMiddleware', function() {
+      assert(arrayContains(window.analytics.methods, 'addIntegrationMiddleware'));
     });
   });
 


### PR DESCRIPTION
This was a mistake, there is no such function addDestinationMiddleware