### PR TITLE
Add setAnonymousId to the AJS stub

### DIFF
--- a/template/snippet.js
+++ b/template/snippet.js
@@ -1,6 +1,7 @@
-(function () {
+(function(){
+
   // Create a queue, but don't obliterate an existing one!
-  var analytics = (window.analytics = window.analytics || []);
+  var analytics = window.analytics = window.analytics || [];
 
   // If the real analytics.js is already on the page return.
   if (analytics.initialize) return;
@@ -8,7 +9,7 @@
   // If the snippet was invoked already show an error.
   if (analytics.invoked) {
     if (window.console && console.error) {
-      console.error("Segment snippet included twice.");
+      console.error('Segment snippet included twice.');
     }
     return;
   }
@@ -19,33 +20,33 @@
 
   // A list of the methods in Analytics.js to stub.
   analytics.methods = [
-    "trackSubmit",
-    "trackClick",
-    "trackLink",
-    "trackForm",
-    "pageview",
-    "identify",
-    "reset",
-    "group",
-    "track",
-    "ready",
-    "alias",
-    "debug",
-    "page",
-    "once",
-    "off",
-    "on",
-    "addSourceMiddleware",
-    "addIntegrationMiddleware",
-    "setAnonymousId",
+    'trackSubmit',
+    'trackClick',
+    'trackLink',
+    'trackForm',
+    'pageview',
+    'identify',
+    'reset',
+    'group',
+    'track',
+    'ready',
+    'alias',
+    'debug',
+    'page',
+    'once',
+    'off',
+    'on',
+    'addSourceMiddleware',
+    'addIntegrationMiddleware',
+    'setAnonymousId'
   ];
 
   // Define a factory to create stubs. These are placeholders
   // for methods in Analytics.js so that you never have to wait
   // for it to load to actually record data. The `method` is
   // stored as the first argument, so we can replay the data.
-  analytics.factory = function (method) {
-    return function () {
+  analytics.factory = function(method){
+    return function(){
       var args = Array.prototype.slice.call(arguments);
       args.unshift(method);
       analytics.push(args);
@@ -61,31 +62,29 @@
 
   // Define a method to load Analytics.js from our CDN,
   // and that will be sure to only ever load it once.
-  analytics.load = function (key, options) {
+  analytics.load = function(key, options){
     // Create an async script element based on your key.
-    var script = document.createElement("script");
-    script.type = "text/javascript";
+    var script = document.createElement('script');
+    script.type = 'text/javascript';
     script.async = true;
-    script.src =
-      "https://<%= settings.host %>/analytics.js/v1/" +
-      key +
-      "/analytics.min.js";
+    script.src = 'https://<%= settings.host %>/analytics.js/v1/'
+      + key + '/analytics.min.js';
 
     // Insert our script next to the first script element.
-    var first = document.getElementsByTagName("script")[0];
+    var first = document.getElementsByTagName('script')[0];
     first.parentNode.insertBefore(script, first);
     analytics._loadOptions = options;
   };
 
   // Add a version to keep track of what's in the wild.
-  analytics.SNIPPET_VERSION = "4.1.0";
+  analytics.SNIPPET_VERSION = '4.1.0';
 
   // Load Analytics.js with your key, which will automatically
   // load the tools you've enabled for your account. Boosh!
-  ("<%= settings.load %>");
+  '<%= settings.load %>'
 
   // Make the first page call to load the integrations. If
   // you'd like to manually name or tag the page, edit or
   // move this call however you'd like.
-  ("<%= settings.page %>");
+  '<%= settings.page %>'
 })();

--- a/template/snippet.js
+++ b/template/snippet.js
@@ -1,7 +1,6 @@
-(function(){
-
+(function () {
   // Create a queue, but don't obliterate an existing one!
-  var analytics = window.analytics = window.analytics || [];
+  var analytics = (window.analytics = window.analytics || []);
 
   // If the real analytics.js is already on the page return.
   if (analytics.initialize) return;
@@ -9,7 +8,7 @@
   // If the snippet was invoked already show an error.
   if (analytics.invoked) {
     if (window.console && console.error) {
-      console.error('Segment snippet included twice.');
+      console.error("Segment snippet included twice.");
     }
     return;
   }
@@ -20,32 +19,33 @@
 
   // A list of the methods in Analytics.js to stub.
   analytics.methods = [
-    'trackSubmit',
-    'trackClick',
-    'trackLink',
-    'trackForm',
-    'pageview',
-    'identify',
-    'reset',
-    'group',
-    'track',
-    'ready',
-    'alias',
-    'debug',
-    'page',
-    'once',
-    'off',
-    'on',
-    'addSourceMiddleware',
-    'addIntegrationMiddleware'
+    "trackSubmit",
+    "trackClick",
+    "trackLink",
+    "trackForm",
+    "pageview",
+    "identify",
+    "reset",
+    "group",
+    "track",
+    "ready",
+    "alias",
+    "debug",
+    "page",
+    "once",
+    "off",
+    "on",
+    "addSourceMiddleware",
+    "addIntegrationMiddleware",
+    "setAnonymousId",
   ];
 
   // Define a factory to create stubs. These are placeholders
   // for methods in Analytics.js so that you never have to wait
   // for it to load to actually record data. The `method` is
   // stored as the first argument, so we can replay the data.
-  analytics.factory = function(method){
-    return function(){
+  analytics.factory = function (method) {
+    return function () {
       var args = Array.prototype.slice.call(arguments);
       args.unshift(method);
       analytics.push(args);
@@ -61,29 +61,31 @@
 
   // Define a method to load Analytics.js from our CDN,
   // and that will be sure to only ever load it once.
-  analytics.load = function(key, options){
+  analytics.load = function (key, options) {
     // Create an async script element based on your key.
-    var script = document.createElement('script');
-    script.type = 'text/javascript';
+    var script = document.createElement("script");
+    script.type = "text/javascript";
     script.async = true;
-    script.src = 'https://<%= settings.host %>/analytics.js/v1/'
-      + key + '/analytics.min.js';
+    script.src =
+      "https://<%= settings.host %>/analytics.js/v1/" +
+      key +
+      "/analytics.min.js";
 
     // Insert our script next to the first script element.
-    var first = document.getElementsByTagName('script')[0];
+    var first = document.getElementsByTagName("script")[0];
     first.parentNode.insertBefore(script, first);
     analytics._loadOptions = options;
   };
 
   // Add a version to keep track of what's in the wild.
-  analytics.SNIPPET_VERSION = '4.1.0';
+  analytics.SNIPPET_VERSION = "4.1.0";
 
   // Load Analytics.js with your key, which will automatically
   // load the tools you've enabled for your account. Boosh!
-  '<%= settings.load %>'
+  ("<%= settings.load %>");
 
   // Make the first page call to load the integrations. If
   // you'd like to manually name or tag the page, edit or
   // move this call however you'd like.
-  '<%= settings.page %>'
+  ("<%= settings.page %>");
 })();

--- a/test/snippet.test.js
+++ b/test/snippet.test.js
@@ -153,6 +153,10 @@ describe('snippet', function() {
     it('.addIntegrationMiddleware', function() {
       assert(arrayContains(window.analytics.methods, 'addIntegrationMiddleware'));
     });
+
+    it('.setAnonymousId', function() {
+      assert(arrayContains(window.analytics.methods, 'setAnonymousId'));
+    });
   });
 
   describe('.factory', function() {


### PR DESCRIPTION
This PR compliments this change: https://github.com/segmentio/analytics.js-private/pull/543. One of the customers requesting setting anonymousId before the library sets the auto-generated id. This stub method will allow that. 