### PR TITLE
added ajsPath option

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -53,6 +53,7 @@ function defaults(options) {
   options || (options = {});
   options.apiKey || (options.apiKey = 'YOUR_API_KEY');
   options.host || (options.host = 'cdn.segment.com');
+  options.ajsPath || (options.ajsPath = '/analytics.js/v1/\' + key + \'/analytics.min.js');
   if (!has.call(options, 'page')) options.page = true;
   if (!has.call(options, 'load')) options.load = true;
   return options;

--- a/template/snippet.js
+++ b/template/snippet.js
@@ -68,8 +68,7 @@
     var script = document.createElement('script');
     script.type = 'text/javascript';
     script.async = true;
-    script.src = 'https://<%= settings.host %>/analytics.js/v1/'
-      + key + '/analytics.min.js';
+    script.src = 'https://<%= settings.host %><%= settings.ajsPath %>';
 
     // Insert our script next to the first script element.
     var first = document.getElementsByTagName('script')[0];

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -19,6 +19,15 @@ describe('snippet', function() {
         'example.com/analytics.js/v1');
     });
 
+    it('should set the ajs path', function() {
+      assertContains(
+        snippet.max({ 
+          host: 'example.com',
+          ajsPath: '/something/else.min.js'
+        }),
+        'example.com/something/else.min.js');
+    });
+
     it('should set the api key', function() {
       assertContains(
         snippet.max({ apiKey: 'key' }),


### PR DESCRIPTION
## Description
This PR adds an option `ajsPath` to override the default analytics.min.js location

## Testing
**Using default**
```
snippet.max({})
```
The relevant bit of generated snippet:
```
  analytics.load = function(key, options){
    // Create an async script element based on your key.
    var script = document.createElement('script');
    script.type = 'text/javascript';
    script.async = true;
    script.src = 'https://cdn.segment.com/analytics.js/v1/' + key + '/analytics.min.js';

    // Insert our script next to the first script element.
    var first = document.getElementsByTagName('script')[0];
    first.parentNode.insertBefore(script, first);
    analytics._loadOptions = options;
  };
```

**Setting ajsPath**
```
snippet.max({ajsPath: '/foo/bar.min.js'})
```
```
  analytics.load = function(key, options){
    // Create an async script element based on your key.
    var script = document.createElement('script');
    script.type = 'text/javascript';
    script.async = true;
    script.src = 'https://cdn.segment.com/foo/bar.min.js';

    // Insert our script next to the first script element.
    var first = document.getElementsByTagName('script')[0];
    first.parentNode.insertBefore(script, first);
    analytics._loadOptions = options;
  };
```