### PR TITLE
Sets analytics.SNIPPET_VERSION to package.json version

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -5,14 +5,15 @@ var path = require('path');
 var template = require('lodash/template');
 var minify = require('uglify-js').minify;
 var mkdirp = require('mkdirp');
+var packageJSON = require('../package.json')
 
 var source = fs.readFileSync(path.join(__dirname, '../template/snippet.js'), { encoding: 'utf8' });
 
 var loadRegex = /['"](<%= settings\.load %>)['"];?/;
 var pageRegex = /['"](<%= settings\.page %>)['"]/;
 var lineRegex = /(<%= settings\.load %>|<%= settings\.page %>|}}\(\);)/g;
-
-var snippet = template(source.replace(loadRegex, '$1').replace(pageRegex, '$1'), { variable: 'settings' });
+var versionRegex = /<%= settings\.version %>/;
+var snippet = template(source.replace(loadRegex, '$1').replace(pageRegex, '$1').replace(versionRegex, packageJSON.version), { variable: 'settings' });
 var snippetMin = template(minify(source, {
   mangle: { except: ['analytics'] },
   compress: { sequences: false, side_effects: false },

--- a/template/snippet.js
+++ b/template/snippet.js
@@ -77,7 +77,7 @@
   };
 
   // Add a version to keep track of what's in the wild.
-  analytics.SNIPPET_VERSION = '4.1.0';
+  analytics.SNIPPET_VERSION = '<%= settings.version %>';
 
   // Load Analytics.js with your key, which will automatically
   // load the tools you've enabled for your account. Boosh!

--- a/test/snippet.test.js
+++ b/test/snippet.test.js
@@ -51,6 +51,10 @@ describe('snippet', function() {
     assert(length === scripts.length);
   });
 
+  it('should set SNIPPET_VERSION to module version', function() {
+    assert(require('../package.json').version === window.analytics.SNIPPET_VERSION)
+  })
+
   it('should warn using console.error when the snippet is included > 1', function() {
     snippet();
     var args = window.console.error.args;

--- a/test/snippet.test.js
+++ b/test/snippet.test.js
@@ -52,8 +52,8 @@ describe('snippet', function() {
   });
 
   it('should set SNIPPET_VERSION to module version', function() {
-    assert(require('../package.json').version === window.analytics.SNIPPET_VERSION)
-  })
+    assert(require('../package.json').version === window.analytics.SNIPPET_VERSION);
+  });
 
   it('should warn using console.error when the snippet is included > 1', function() {
     snippet();


### PR DESCRIPTION
# Description
This PR sets `analytics.SNIPPET_VERSION` at build-time using the module version found in package.json rather than having it hardcoded.

# Testing
The generated code looks like this:
```
  // Add a version to keep track of what's in the wild.
  analytics.SNIPPET_VERSION = '4.12.0';
```