### PR TITLE
Add TypeScript definitions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -38,6 +38,7 @@ var contents = snippet.max({
   * `apiKey`: the `apiKey` to load in the snippet.
   * `page`: the options to pass to `analytics.page`. if `page` is `false`, then the `page()` call will be omitted.
   * `load`: if set to `false` the `load()` call will be omitted. This is useful for if you want dynamically control the load process on the client-side for things like GDPR.
+  * `ajsPath`: override the default analytics.min.js location
 
 
 ### snippet.min(options)

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "description": "Templating methods for rendering the analytics.js snippet.",
   "main": "lib/index.js",
   "license": "MIT",
+  "typings": "./types.d.ts",
   "dependencies": {
     "@ndhoule/map": "^2.0.1"
   },

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,0 +1,40 @@
+declare module '@segment/snippet' {
+    interface PageOptions {
+        category?: string
+        name?: string
+        properties?: {
+            [key: string]: string | number
+        }
+    }
+
+    interface Options {
+        /** The domain name where the analytics.js script is hosted. */
+        host?: string
+        /** The apiKey to load in the snippet. */
+        apiKey?: string
+        ajsPath?: string
+        /**
+         * The options to pass to `analytics.page`. if page is false, then the
+         * `page()` call will be omitted.
+         */
+        page?: boolean | PageOptions
+        /**
+         * If set to false the `load()` call will be omitted. This is useful for if
+         * you want dynamically control the load process on the client-side for
+         * things like GDPR.
+         */
+        load?: boolean
+    }
+
+    /**
+     * Returns the maxified version of the analytics.js snippet given a set of
+     * options.
+     */
+    export function max(options?: Options): string
+
+    /**
+     * Returns the minified version of the snippet.
+     */
+    export function min(options?: Options): string
+}
+


### PR DESCRIPTION
# Description

We'd like to use this library in a Next.js application that we're building with TypeScript but it complains that there is no type declarations for the module. This PR adds a TypeScript declaration for the `@segment/snippet` module.

I've also documented the `ajsPath` option from #50 merged in 7119bcc.

## Preview

Editor/tsserver integration working

![image](https://user-images.githubusercontent.com/5564612/97134175-8e079580-17a0-11eb-80b5-eac6417f7f02.png)

![image](https://user-images.githubusercontent.com/5564612/97134180-9790fd80-17a0-11eb-8f3a-fd1b89aaede3.png)

# Testing

I've verified that this works with `npm link` in our TypeScript project locally. There are no functionality changes so I expect this would work when published as long as the `types.d.ts` file is included in the package.