### PR TITLE
add _writekey field (analytics-next)

### DIFF
--- a/template/snippet.js
+++ b/template/snippet.js
@@ -75,6 +75,7 @@
     first.parentNode.insertBefore(script, first);
     analytics._loadOptions = options;
   };
+  analytics._writeKey = '<%= settings.apiKey %>'
 
   // Add a version to keep track of what's in the wild.
   analytics.SNIPPET_VERSION = '<%= settings.version %>';

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -34,6 +34,13 @@ describe('snippet', function() {
         'analytics.load("key")');
     });
 
+    it('should set the _writekey', function() {
+      assertContains(
+        snippet.max({ apiKey: 'foo' }),
+        // eslint-disable-next-line
+        "analytics._writeKey = 'foo'");
+    });
+
     it('should not include page if explicitly omitted', function() {
       assertDoesNotContain(
         snippet.max({ page: false }),
@@ -92,6 +99,12 @@ describe('snippet', function() {
       assertContains(
         snippet.min({ apiKey: 'key' }),
         'analytics.load("key")');
+    });
+
+    it('should set the _writekey', function() {
+      assertContains(
+        snippet.min({ apiKey: 'foo' }),
+        'analytics._writeKey="foo"');
     });
 
     it('should be shorter than max', function() {


### PR DESCRIPTION
This PR adds a _writekey field for AJSN to consume in case the customer has aliased their CDN