### PR TITLE
Introduce the `analytics._cdn` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/snippet",
   "author": "Segment.io <friends@segment.com>",
-  "version": "4.14.2",
+  "version": "4.15.0",
   "repository": "git://github.com/segmentio/snippet.git",
   "description": "Templating methods for rendering the analytics.js snippet.",
   "main": "lib/index.js",

--- a/template/snippet.js
+++ b/template/snippet.js
@@ -1,4 +1,4 @@
-(function() {
+(function(){
 
   // Create a queue, but don't obliterate an existing one!
   var analytics = window.analytics = window.analytics || [];
@@ -46,8 +46,8 @@
   // for methods in Analytics.js so that you never have to wait
   // for it to load to actually record data. The `method` is
   // stored as the first argument, so we can replay the data.
-  analytics.factory = function(method) {
-    return function() {
+  analytics.factory = function(method){
+    return function(){
       var args = Array.prototype.slice.call(arguments);
       args.unshift(method);
       analytics.push(args);
@@ -63,7 +63,7 @@
 
   // Define a method to load Analytics.js from our CDN,
   // and that will be sure to only ever load it once.
-  analytics.load = function(key, options) {
+  analytics.load = function(key, options){
     // Create an async script element based on your key.
     var script = document.createElement('script');
     script.type = 'text/javascript';

--- a/template/snippet.js
+++ b/template/snippet.js
@@ -1,4 +1,4 @@
-(function(){
+(function() {
 
   // Create a queue, but don't obliterate an existing one!
   var analytics = window.analytics = window.analytics || [];
@@ -46,8 +46,8 @@
   // for methods in Analytics.js so that you never have to wait
   // for it to load to actually record data. The `method` is
   // stored as the first argument, so we can replay the data.
-  analytics.factory = function(method){
-    return function(){
+  analytics.factory = function(method) {
+    return function() {
       var args = Array.prototype.slice.call(arguments);
       args.unshift(method);
       analytics.push(args);
@@ -63,7 +63,7 @@
 
   // Define a method to load Analytics.js from our CDN,
   // and that will be sure to only ever load it once.
-  analytics.load = function(key, options){
+  analytics.load = function(key, options) {
     // Create an async script element based on your key.
     var script = document.createElement('script');
     script.type = 'text/javascript';
@@ -76,6 +76,8 @@
     analytics._loadOptions = options;
   };
   analytics._writeKey = '<%= settings.apiKey %>'
+
+  analytics._cdn = '<%= settings.host %>'
 
   // Add a version to keep track of what's in the wild.
   analytics.SNIPPET_VERSION = '<%= settings.version %>';

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -21,7 +21,7 @@ describe('snippet', function() {
 
     it('should set the ajs path', function() {
       assertContains(
-        snippet.max({
+        snippet.max({ 
           host: 'example.com',
           ajsPath: '/something/else.min.js'
         }),

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -21,7 +21,7 @@ describe('snippet', function() {
 
     it('should set the ajs path', function() {
       assertContains(
-        snippet.max({ 
+        snippet.max({
           host: 'example.com',
           ajsPath: '/something/else.min.js'
         }),
@@ -45,6 +45,13 @@ describe('snippet', function() {
         snippet.max({ apiKey: 'foo' }),
         // eslint-disable-next-line
         "analytics._writeKey = 'foo'");
+    });
+
+    it('should set the _cdn', function() {
+      assertContains(
+        snippet.max({ host: 'example.com' }),
+        // eslint-disable-next-line
+        "analytics._cdn = 'example.com'");
     });
 
     it('should not include page if explicitly omitted', function() {


### PR DESCRIPTION
This PR introduces the `analytics._cdn` field (with the same value as
cdn host) so all bundles are loaded from the custom CDN.