### PR TITLE
fix(types): Property 'All' is optional but undefined not allowed

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -9,7 +9,6 @@ declare module '@segment/snippet' {
 
     interface LoadOptions {
         integrations?: {
-            All?: boolean
             [key: string]: boolean
         }
     }


### PR DESCRIPTION
This resolves #69

This type is not useful because it says something like:
> The key has to be a string, but can also be "All"

But `All` is a string!
> But `All` can be undefined

So not all strings can be undefined, only `All` why?
> But a key with a string as type can only be boolean, not undefined

That means :
```ts
// allowed
{ }
{ All: undefined }
{ All: true }
{ All: false }
{ hotjar: true }
{ hotjar: false }

// NOT allowed
{ hotjar: undefined }
```
Since this does not make sense and TS is also saying this 2 rules can not match each other we have to change the Type.

With this PR I introduce the new types by removing the `All` rule. So now we can pass in all strings, also the string `All` but the values can only be `true` or `false`. If you don't want to pass the `All` key, just do not pass it in the integrations object.
So now the following is the case:

```ts
// allowed
{ }
{ All: true }
{ All: false }
{ hotjar: true }
{ hotjar: false }

// NOT allowed
{ All: undefined } // this one changed in this PR
{ hotjar: undefined }
```