### PR TITLE
Removed runtime dependencies

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,6 @@
  * Module Dependencies.
  */
 
-var map = require('@ndhoule/map');
 var maxTemplate = require('../dist/max.template');
 var minTemplate = require('../dist/min.template');
 
@@ -78,14 +77,16 @@ function defaults(options) {
 function renderPage(page) {
   if (!page) return '';
 
-  var args = [];
-
-  if (page.category) args.push(page.category);
-  if (page.name) args.push(page.name);
-  if (page.properties) args.push(page.properties);
+  var argsStringified = [];
 
   // eslint-disable-next-line no-restricted-globals
-  var res = 'analytics.page(' + map(JSON.stringify, args).join(', ') + ');';
+  if (page.category) argsStringified.push(JSON.stringify(page.category));
+  // eslint-disable-next-line no-restricted-globals
+  if (page.name) argsStringified.push(JSON.stringify(page.name));
+  // eslint-disable-next-line no-restricted-globals
+  if (page.properties) argsStringified.push(JSON.stringify(page.properties));
+
+  var res = 'analytics.page(' + argsStringified.join(', ') + ');';
 
   return res;
 }

--- a/package.json
+++ b/package.json
@@ -13,9 +13,7 @@
     "e2e-tests": "yarn jest --runTestsByPath --forceExit e2e-tests/*",
     "e2e": "yarn build && start-server-and-test example http://localhost:8080 e2e-tests"
   },
-  "dependencies": {
-    "@ndhoule/map": "^2.0.1"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@segment/clear-env": "^2.0.3",
     "@segment/eslint-config": "^3.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -533,13 +533,6 @@
   resolved "https://registry.yarnpkg.com/@ndhoule/keys/-/keys-2.0.0.tgz#3d64ae677c65a261747bf3a457c62eb292a4e0ce"
   integrity sha1-PWSuZ3xlomF0e/OkV8YuspKk4M4=
 
-"@ndhoule/map@^2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@ndhoule/map/-/map-2.0.1.tgz#f5ca0a47424ea67f46e2a6d499b9e9bc886aefa8"
-  integrity sha1-9coKR0JOpn9G4qbUmbnpvIhq76g=
-  dependencies:
-    "@ndhoule/each" "^2.0.1"
-
 "@segment/clear-ajax@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@segment/clear-ajax/-/clear-ajax-1.0.2.tgz#614c53a9e1bc69d38dd0b6aedbb1e86c3b86b59b"


### PR DESCRIPTION
I noticed there was only 1 runtime dependency, and it looks like it can be removed pretty easily. For people who have to audit dependencies, having fewer (now zero) dependencies makes their lives a bit easier.

It looks like the package is a simple polyfill for `Array.map`. If/when this library bumps its supported IE version to 9+ (!!), it should be possible to use `Array.map` if desired.

Note I only updated yarn.lock, not package-lock.json. Using a newer version of npm can add a lot of noise to the package-lock.json diff. You may want to run an `npm install` using the version of npm you use. (However, yarn and npm both advise against having two lockfiles for two different package managers.)