### PR TITLE
make stale reference-proof

### DIFF
--- a/template/snippet.js
+++ b/template/snippet.js
@@ -50,6 +50,9 @@
     return function(){
       var args = Array.prototype.slice.call(arguments);
       args.unshift(method);
+      if (window.analytics.initialize) {
+        return window.analytics[e].apply(window.analytics, arguments);
+      }
       analytics.push(args);
       return analytics;
     };

--- a/template/snippet.js
+++ b/template/snippet.js
@@ -53,7 +53,7 @@
       if (window.analytics.initialize) {
         // Sometimes users assigned analytics to a variable before analytics is done loading, resulting in a stale reference.
         // If so, proxy any calls to the 'real' analytics instance.
-        return window.analytics[e].apply(window.analytics, arguments);
+        return window.analytics[method].apply(window.analytics, arguments);
       }
       analytics.push(args);
       return analytics;

--- a/template/snippet.js
+++ b/template/snippet.js
@@ -48,13 +48,13 @@
   // stored as the first argument, so we can replay the data.
   analytics.factory = function(method){
     return function(){
-      var args = Array.prototype.slice.call(arguments);
-      args.unshift(method);
       if (window.analytics.initialized) {
         // Sometimes users assigned analytics to a variable before analytics is done loading, resulting in a stale reference.
         // If so, proxy any calls to the 'real' analytics instance.
         return window.analytics[method].apply(window.analytics, arguments);
       }
+      var args = Array.prototype.slice.call(arguments);
+      args.unshift(method);
       analytics.push(args);
       return analytics;
     };

--- a/template/snippet.js
+++ b/template/snippet.js
@@ -51,6 +51,8 @@
       var args = Array.prototype.slice.call(arguments);
       args.unshift(method);
       if (window.analytics.initialize) {
+        // Sometimes users assigned analytics to a variable before analytics is done loading, resulting in a stale reference.
+        // If so, proxy any calls to the 'real' analytics instance.
         return window.analytics[e].apply(window.analytics, arguments);
       }
       analytics.push(args);

--- a/template/snippet.js
+++ b/template/snippet.js
@@ -50,7 +50,7 @@
     return function(){
       var args = Array.prototype.slice.call(arguments);
       args.unshift(method);
-      if (window.analytics.initialize) {
+      if (window.analytics.initialized) {
         // Sometimes users assigned analytics to a variable before analytics is done loading, resulting in a stale reference.
         // If so, proxy any calls to the 'real' analytics instance.
         return window.analytics[method].apply(window.analytics, arguments);


### PR DESCRIPTION
test/repro here: https://github.com/silesky/segment-stale-reference/tree/main

The "minified" updated function is:
```ts
 analytics.factory = function (e) {
      return function () {
        if (window.analytics.initialized) {
          return window.analytics[e].apply(window.analytics, arguments);
        }
        var t = Array.prototype.slice.call(arguments);
        t.unshift(e);
        analytics.push(t);
        return analytics
      }
};
```